### PR TITLE
Run workflow manually

### DIFF
--- a/.github/workflows/deploy-flyio.yaml
+++ b/.github/workflows/deploy-flyio.yaml
@@ -3,9 +3,10 @@ name: Fly Deploy CD
 on:
   workflow_call:
   workflow_run:
-    workflows: [Tests/Checks CI, Dependabot auto-merge]
+    workflows: [Tests/Checks CI]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/run-ci-checks.yaml
+++ b/.github/workflows/run-ci-checks.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: ["main"]
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Add the option to run workflow(s) manually.

- add option to run a workflow manually
- remove run after Dependabot auto-merge (not triggered)

see [Configuring a workflow to run manually](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually)
