### PR TITLE
Use platform specification in Docker Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,14 @@ Django 4.2 and Python 3.12
   ([#28](https://github.com/hdigital/parlgov-web/pull/28))
 - Add links to PR, issue, or commit for all entries in the 'changelog'
   ([#30](https://github.com/hdigital/parlgov-web/pull/30))
-- Restructure 'factories' import
-  ([#23](https://github.com/hdigital/parlgov-web/pull/23))
 - Use 'CITATION.cff' for Zenodo metadata
   ([#32](https://github.com/hdigital/parlgov-web/pull/32))
 - Harmonize project information and metadata
   ([#38](https://github.com/hdigital/parlgov-web/issues/38))
+- Restructure 'factories' import
+  ([#23](https://github.com/hdigital/parlgov-web/pull/23))
+- Use platform specification in Docker Compose
+  ([#40](https://github.com/hdigital/parlgov-web/pull/40))
 
 ### Removed
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   web:
+    platform: linux/amd64
     build:
       dockerfile: ./_docker/Dockerfile-local-dev
     command: python ./app/manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Specify `linux/amd64` platform in Docker Compose for consistent builds across ARM and x86 architectures.
