### PR TITLE
Harmonize 'yaml' quoting

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,13 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: pip
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
     # Disable version updates (only security updates)
     open-pull-requests-limit: 0
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: monthly

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -18,7 +18,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository
-          path: "_docs"
+          path: _docs
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -4,7 +4,7 @@ name: Docs Deploy GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,8 +15,7 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allows one deployment at a time and lets in-progress runs finish
 concurrency:
   group: pages
   cancel-in-progress: false

--- a/.github/workflows/run-ci-checks.yaml
+++ b/.github/workflows/run-ci-checks.yaml
@@ -2,9 +2,9 @@ name: Tests/Checks CI
 
 on:
   push:
-    branches: ["main"]
+    branches: [main]
   pull_request:
-    branches: ["main"]
+    branches: [main]
   workflow_call:
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Django 5.2 and Python 3.13
 
 - Use 'uv' for 'pip compile'
   ([#87](https://github.com/hdigital/parlgov-web/pull/87))
+- Harmonize 'yaml' quoting
+  ([#88](https://github.com/hdigital/parlgov-web/pull/88))
 
 ### Removed
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,6 @@ services:
       - DJANGO_DEBUG=True
       - DATABASE_URL=sqlite:////app/app/parlgov.sqlite
     ports:
-      - "8000:8000"
+      - 8000:8000
     volumes:
       - .:/app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,6 @@ services:
       - DJANGO_DEBUG=True
       - DATABASE_URL=sqlite:////app/app/parlgov.sqlite
     ports:
-      - 8000:8000
+      - "8000:8000" # quoted per 'compose-spec'
     volumes:
       - .:/app

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -15,8 +15,8 @@ extra:
   generator: false
 
 nav:
-  - "index.md"
-  - "usage.md"
-  - "development.md"
-  - "migration.md"
-  - "project-history.md"
+  - index.md
+  - usage.md
+  - development.md
+  - migration.md
+  - project-history.md


### PR DESCRIPTION
Harmonize 'yaml' quoting and quote a scalar only when it would otherwise misparse.

__Background__

Minimal quoting is good 'yaml' practice. However, some scalars silently misparse under YAML 1.1: sexagesimal values (`22:22` → `1342`), octals (`0755` → `493`), and implicit booleans (`no`/`off`/`yes`). Quote only when a value would misparse.

In Docker Compose, use quotes in 'ports' and 'environment' (bool) values (see [compose-spec](https://github.com/compose-spec/compose-spec/blob/main/spec.md)).

_Claude Code (Sonnet 5): drafted_
