### PR TITLE
Add 'vale' prose linting for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ learning-diary.md
 # Development
 .vscode/settings.json
 node_modules
-.vale/styles
+.vale/styles/*
+!.vale/styles/config
 
 # macOS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ learning-diary.md
 # Development
 .vscode/settings.json
 node_modules
+.vale/styles
 
 # macOS
 .DS_Store

--- a/.vale.ini
+++ b/.vale.ini
@@ -7,10 +7,10 @@
 StylesPath = .vale/styles
 MinAlertLevel = warning
 
-Packages = write-good
+Packages = write-good, Google
 
 [*.md]
-BasedOnStyles = write-good
+BasedOnStyles = write-good, Google
 
 # Passive voice is common (and fine) in technical/historical docs
 write-good.Passive = NO
@@ -18,6 +18,14 @@ write-good.Passive = NO
 # Style opinions are advisory, not blocking
 write-good.ThereIs = warning
 
+# Docs and CHANGELOG use a spaced em dash throughout; that's our convention
+Google.EmDash = NO
+
 # Generated reference, not prose
 [docs/assets/parlgov-codebook.md]
 BasedOnStyles =
+
+# First-person narrative is intentional for the project history
+[docs/project-history.md]
+Google.FirstPerson = NO
+Google.We = NO

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,23 @@
+# Configure prose linting with 'vale' (run via 'uvx', not a project dependency)
+# https://vale.sh/docs/topics/config/
+#
+# sync styles: uvx vale sync
+# run:         uvx vale docs README.md CHANGELOG.md
+
+StylesPath = .vale/styles
+MinAlertLevel = warning
+
+Packages = write-good
+
+[*.md]
+BasedOnStyles = write-good
+
+# Passive voice is common (and fine) in technical/historical docs
+write-good.Passive = NO
+
+# Style opinions are advisory, not blocking
+write-good.ThereIs = warning
+
+# Generated reference, not prose
+[docs/assets/parlgov-codebook.md]
+BasedOnStyles =

--- a/.vale.ini
+++ b/.vale.ini
@@ -11,6 +11,9 @@ MinAlertLevel = warning
 # .vale/styles/config/vocabularies/Project/accept.txt)
 Vocab = Project
 
+
+## Packages configuration
+
 Packages = write-good, Google
 
 [*.md]
@@ -19,20 +22,19 @@ BasedOnStyles = write-good, Google
 # Passive voice is common (and fine) in technical/historical docs
 write-good.Passive = NO
 
-# Style opinions are advisory, not blocking
-write-good.ThereIs = warning
-
-# Docs and CHANGELOG use a spaced em dash throughout; that's our convention
+# Docs and 'changelog' use a spaced em dash throughout
 Google.EmDash = NO
 
-# 'e.g.' is our preferred style, not a mistake
+# 'e.g.' is a preferred style
 Google.Latin = NO
 
-# Headings use Title Case + emoji throughout; CHANGELOG headers are
-# '[version] — date', not sentence-case prose
+# Headings use Title Case + emoji throughout
 Google.Headings = NO
 
-# Generated reference, not prose
+
+## Document level configuration
+
+# Skip all style checks in codebook
 [docs/assets/parlgov-codebook.md]
 BasedOnStyles =
 
@@ -40,8 +42,3 @@ BasedOnStyles =
 [docs/project-history.md]
 Google.FirstPerson = NO
 Google.We = NO
-
-# False positive: 2-item list ('party IDs and party names'), not a
-# 3-item series that needs an Oxford comma
-[docs/migration.md]
-Google.OxfordComma = NO

--- a/.vale.ini
+++ b/.vale.ini
@@ -7,6 +7,10 @@
 StylesPath = .vale/styles
 MinAlertLevel = warning
 
+# Project-specific terms accepted everywhere (see
+# .vale/styles/config/vocabularies/Project/accept.txt)
+Vocab = Project
+
 Packages = write-good, Google
 
 [*.md]
@@ -21,6 +25,13 @@ write-good.ThereIs = warning
 # Docs and CHANGELOG use a spaced em dash throughout; that's our convention
 Google.EmDash = NO
 
+# 'e.g.' is our preferred style, not a mistake
+Google.Latin = NO
+
+# Headings use Title Case + emoji throughout; CHANGELOG headers are
+# '[version] — date', not sentence-case prose
+Google.Headings = NO
+
 # Generated reference, not prose
 [docs/assets/parlgov-codebook.md]
 BasedOnStyles =
@@ -29,3 +40,8 @@ BasedOnStyles =
 [docs/project-history.md]
 Google.FirstPerson = NO
 Google.We = NO
+
+# False positive: 2-item list ('party IDs and party names'), not a
+# 3-item series that needs an Oxford comma
+[docs/migration.md]
+Google.OxfordComma = NO

--- a/.vale/styles/config/vocabularies/Project/accept.txt
+++ b/.vale/styles/config/vocabularies/Project/accept.txt
@@ -1,0 +1,3 @@
+(?i)application
+(?i)admin
+(?i)open-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Django 5.2 and Python 3.13
 ### Added
 
 - Add 'vale' prose linting for docs
+  ([#95](https://github.com/hdigital/parlgov-web/pull/95))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Django 5.2 and Python 3.13
   ([#53](https://github.com/hdigital/parlgov-web/pull/53),
    [#55](https://github.com/hdigital/parlgov-web/pull/55),
    [#56](https://github.com/hdigital/parlgov-web/pull/56))
-- Use '/api/v1' as API url for better versioning support
+- Use '/api/v1' as API URL for better versioning support
   ([#29](https://github.com/hdigital/parlgov-web/pull/29))
 - Recreate project data (fixture, schema, codebook)
   ([#65](https://github.com/hdigital/parlgov-web/pull/65))
@@ -125,7 +125,7 @@ Django 4.2 and Python 3.12
 
 ### Fixed
 
-- Specify database url for Docker
+- Specify database URL for Docker
   ([ebeee42](https://github.com/hdigital/parlgov-web/commit/ebeee42))
 
 ## [v24.08] — 2024-08-24
@@ -143,7 +143,7 @@ Django 5.x and Python 3.1x
 
 ### Changed
 
-- _for changes in functionality_
+- _for changes in existing features_
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Django 5.2 and Python 3.13
 
 ### Added
 
-- _for new features_
+- Add 'vale' prose linting for docs
 
 ### Changed
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,6 +93,16 @@ Build static site documentation
 mkdocs build --clean --strict
 ```
 
+### Prose linting · ✍️
+
+Check docs and Markdown files for style issues with
+[Vale](https://vale.sh/), run via `uvx` (see `.vale.ini`)
+
+```sh
+uvx vale sync
+uvx vale docs README.md CHANGELOG.md
+```
+
 ### Graph models · 📐
 
 Create or update [graph

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,7 +44,7 @@ Database tables use prefixes.
 - _docs_ — documentation tables (e.g., codebook, news)
 - _view_ — main data tables (database views, _see below_)
 
-Additional tables are included by Django in the app database (`parlgov.sqlite`).
+Django also includes other tables in the app database (`parlgov.sqlite`).
 
 A visualization of the data tables is provided in `graph-models_data.png` (see
 below).
@@ -66,7 +66,7 @@ python manage.py update_cabinet_election
 
 ### Views · 🔬
 
-There are three main tables (parties, elections, cabinets) provided as database
+Three main tables (parties, elections, cabinets) are provided as database
 views. They include the most frequently used information from the primary
 database tables.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,7 +27,7 @@ pytest --cov
 
 Tests are run randomly with
 [pytest-randomly](https://github.com/pytest-dev/pytest-randomly). This can be
-disabled with
+turned off with
 
 ```sh
 # (.venv) ./app

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,7 +96,7 @@ mkdocs build --clean --strict
 ### Prose linting · ✍️
 
 Check docs and Markdown files for style issues with
-[Vale](https://vale.sh/), run via `uvx` (see `.vale.ini`)
+[Vale](https://vale.sh/), run via `uvx` (see `.vale.ini`).
 
 ```sh
 uvx vale sync

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -64,14 +64,14 @@ This documentation and the checks have not been migrated for the initial version
 of _ParlGov web_. _ParlGov legacy_ also includes a table that documents JSON
 keys.
 
-Data sources are documented with keys in the data tables, and these keys are
-mostly documented and checked in _ParlGov legacy_. A migration of the keys needs
-a substantial revision and is not included in the initial version of _ParlGov
-web_.
+Data sources are documented with keys in the data tables, and most of these
+keys are documented and checked in _ParlGov legacy_. A migration of the keys
+needs a considerable revision and is not included in the initial version of
+_ParlGov web_.
 
 ## External
 
-_ParlGov legacy_ includes additional information, such as party IDs and party
+_ParlGov legacy_ includes further information, such as party IDs and party
 names from other datasets, in database tables with the prefix `external_*`.
 
 These tables were not updated for recent versions of _ParlGov legacy_ and are

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -71,8 +71,8 @@ _ParlGov web_.
 
 ## External
 
-_ParlGov legacy_ includes further information, such as party IDs and party
-names from other datasets, in database tables with the prefix `external_*`.
+_ParlGov legacy_ includes further information such as party IDs and party
+names from other datasets in database tables with the prefix `external_*`.
 
 These tables were not updated for recent versions of _ParlGov legacy_ and are
 not needed in a new version of ParlGov.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -47,7 +47,7 @@ scripts for the calculation have not been migrated.
 
 **Cabinet parties** have been migrated from _ParlGov legacy_.
 
-Cabinet seats have not been included (see above).
+Cabinet seats have not been included (see the preceding section).
 
 _ParlGov legacy_ includes an experimental and incomplete recording of
 _confidence votes_ and _cabinet support parties_ that have not been migrated to

--- a/docs/project-history.md
+++ b/docs/project-history.md
@@ -6,32 +6,32 @@ accessible between 2010 and 2021.
 
 ## History
 
-The earliest Django version of ParlGov I found is from 2007. It was based on a
-SQLite database I created previously. I liked Django right away but was hesitant
+The earliest Django version of ParlGov I found is from 2007, based on a SQLite
+database I had already created. I liked Django right away but was hesitant
 to tie the project to the framework fully. Hence, I initially implemented the
 Django web app as a "user interface" to the database and started hosting it on
 Webfaction. At the time, I did not follow the best practices recommended by
-Django but kept the focus on the database. It was also the time when I learned
+Django but kept the focus on the database. This was also when I learned
 more advanced Python programming concepts through learning Django. This legacy
 is still visible in the code more than a decade later.
 
 I completed and made public an initial version of the site in 2010. At the time,
-I updated and significantly improved the structure of the database and the
+I updated and improved the structure of the database and the
 models by using better table and variable names as well as by restructuring the
 database. That year, I also started using version control, Mercurial at the
 time, so that all changes since 2010 can be tracked. Before 2010, the web app
 required a login.
 
 In 2014, I conducted a major refactoring of the code base and added the Bootstrap
-CSS framework, which led to a significantly more professional website layout.
+CSS framework, which led to a more professional website layout.
 
 Even in 2015, I knew that the web app needed significant refactoring. Newer
 Django versions deprecated some approaches that the code relied on, Python 3
 became mainstream, and there was too much outdated code.
 
-Between 2015 and 2021, I could not find funding to implement a refactoring, and
+Between 2015 and 2021, I could not find funding to carry out a refactoring, and
 I was not in a position to do these updates myself. That is why the project code
-base stalled, although it was happily running online all those years. During
+base stalled, although it kept happily running online all those years. During
 this period, I added data validations, minor bug fixes, and minuscule
 enhancements.
 
@@ -78,12 +78,12 @@ app is risky and potentially error-prone.
 Sixth, _frontend technologies_ have evolved over the last decade. None of these
 tools, Bootstrap as an exception, is used in the app.
 
-Nevertheless, I firmly believe that the models have stood the test of time.
-There are a few minor adjustments I would like to make, and many removals are
-needed. I am convinced that the major models are very robust and include a lot
-of valuable experience gained over the years.
+Still, I firmly believe that the models have stood the test of time. A few
+minor adjustments would be worthwhile, and many removals are needed. I am
+convinced that the major models are robust and include a lot of valuable
+experience gained over the years.
 
-Therefore, the new version is based on the models from the legacy app. All other
+As a result, the new version is based on the models from the legacy app. All other
 code has been written from scratch, and this is not a "second system syndrome"
 but a hard-won insight.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,7 +40,7 @@ See the example of a production deployment in `Dockerfile-flyio`.
 
 ## Installation · 🛠️
 
-Run in codespace, install locally, or use Docker (see above).
+Run in codespace, install locally, or use Docker (see the preceding section).
 
 **Codespace** is fully configured. Load the data and run a local server with
 _just_ commands.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,14 +90,14 @@ python manage.py createsuperuser
 ## Data validation · 🕵🏼‍♀️
 
 All data is validated during the addition to the database with Django. The
-`validate_data` command can run these and additional validations (see below).
+`validate_data` command can run these and other validations (see below).
 
 ```sh
 # (.venv) ./app
 python manage.py validate_data
 ```
 
-Additional validations include
+Other validations include
 
 - parties
     - inclusion criteria check — see priority in `run_include_checks(party)`
@@ -111,7 +111,7 @@ Additional validations include
     - PM for one party specified
     - previous election included
 
-Additional scripts data checks
+Other scripts data checks
 
 - `update_cabinet_election` — check and update election variable in all cabinets
 - `get_elections_no_seats_party` — show elections with missing coding of first loser
@@ -145,7 +145,7 @@ bash scripts/create-codebook.sh
 The website provides an API with [Django REST
 framework](https://www.django-rest-framework.org/).
 
-It is a read-only API; no login is required.
+This is a read-only API; no login is required.
 
 Documentation with an OpenAPI 3 schema is provided in `schema.yaml`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,7 +97,7 @@ All data is validated during the addition to the database with Django. The
 python manage.py validate_data
 ```
 
-Other validations include
+Other validations include:
 
 - parties
     - inclusion criteria check — see priority in `run_include_checks(party)`
@@ -111,7 +111,7 @@ Other validations include
     - PM for one party specified
     - previous election included
 
-Other scripts data checks
+Other scripts data checks:
 
 - `update_cabinet_election` — check and update election variable in all cabinets
 - `get_elections_no_seats_party` — show elections with missing coding of first loser


### PR DESCRIPTION
Add prose linting for docs with [vale](https://github.com/vale-cli/vale), run manually via 'uvx' (not a project dependency).

- lint with 'write-good' and 'Google' style guides
- configure 'vale' (e.g. project vocabulary)
- fix 'vale' issues in 'docs' and 'changelog'
- document the workflow in 'docs/development.md'

Usage

```sh
uvx vale sync
uvx vale docs README.md CHANGELOG.md
```

_Claude Code (Sonnet 5): drafted_